### PR TITLE
Issue-1 the problem with ci/cd job starting fixed

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -5,10 +5,14 @@ on:
 
 jobs:
   tests:
-    runs-on: python:3.10.6-slim
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repo
         uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v5.0.0
+        with:
+          python-version: "3.10.6"
       - name: set up and activate virtual environment
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.2
       - name: Setup Python
         uses: actions/setup-python@v5.0.0
         with:


### PR DESCRIPTION
- issue with starting the on-push ci/cd job is foxed by switching to a standard docked image (ubuntu-latest)
- version of repo checkout action updated to a newer one